### PR TITLE
Fix packaging

### DIFF
--- a/spotify.el
+++ b/spotify.el
@@ -8,6 +8,7 @@
 ;; Keywords: convenience
 ;; Version: 0.3.1
 ;; URL: https://github.com/remvee/spotify-el
+;; Package-Requires: ((cl-lib "0.5"))
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License

--- a/spotify.el
+++ b/spotify.el
@@ -41,8 +41,9 @@
 
 (require 'cl-lib)
 
-(defun spotify-p-dbus ()
-  (string= "gnu/linux" system-type))
+(eval-and-compile
+  (defun spotify-p-dbus ()
+    (string= "gnu/linux" system-type)))
 
 (defun spotify-p-osa ()
   (string= "darwin" system-type))


### PR DESCRIPTION
- Add package dependencies header
- Define `spotify-p-dbus` at compile time for using it in macros.

2nd change fixes byte-compile error issue(This is related to https://github.com/syl20bnr/spacemacs/issues/4848)

```
spotify.el:65:1:Error: Symbol’s function definition is void: spotify-p-dbus
```