### PR TITLE
HOTFIX: Resolving unmatched parentheses error

### DIFF
--- a/spotify.el
+++ b/spotify.el
@@ -44,7 +44,7 @@
 (eval-and-compile
   (defun spotify-p-dbus ()
     (and (string= "gnu/linux" system-type)
-	 (featurep 'dbusbind)))
+         (featurep 'dbusbind))))
 
 (defun spotify-p-osa ()
   (string= "darwin" system-type))


### PR DESCRIPTION
First of all, I'm a daily user of this script - thanks to all the maintainers for a fantastic script!

On to the PR info:

- Issue: Pulling latest changes/updates resulted in an "Unmatched parentheses" warning/error, preventing a successful download and subsequent compilation of script.

- Suggested Solution: Ensuring `spotify-p-dbus` function definition is wrapped completely in its surrounding scope.

Thanks so very much, and all the best!